### PR TITLE
Add app.src file to compile with rebar3

### DIFF
--- a/src/google_oauth.app.src
+++ b/src/google_oauth.app.src
@@ -1,0 +1,16 @@
+{application, google_oauth, [
+	{description, "Google API OAuth 2.0 for Server to Server Applications"},
+	{vsn, "1.0.0"},
+	{id, "git"},
+	{modules, []},
+	{registered, []},
+	{applications, [
+		kernel,
+		stdlib,
+	    inets,
+	    jsx,
+	    ssl
+	]},
+	{mod, {google_oauth_app, []}},
+	{env, []}
+]}.


### PR DESCRIPTION
- rebar3 wont detect this repo to be an erlang app without the app.src file.